### PR TITLE
Add option to enter host name and usage of 'https'

### DIFF
--- a/resources/lib/handler/jdownloader2Handler.py
+++ b/resources/lib/handler/jdownloader2Handler.py
@@ -27,7 +27,12 @@ class cJDownloader2Handler:
         sHost = self.__getHost()
         sPort = self.__getPort()
         ENCODING = 'utf-8'
-        url = "http://{}:{}/{}".format(sHost,sPort,path)
+        if sPort != '':
+            url = "{}:{}/{}".format(sHost,sPort,path)
+        else:
+            url = "{}/{}".format(sHost,path)
+        if not url.startswith("http"):
+            url = "http://" + url
         if params is not None:
             headers = {"Content-Type": "application/x-www-form-urlencoded;charset={}".format(ENCODING),}
             request = urllib2.Request(url, urllib.urlencode(params).encode(ENCODING), headers)

--- a/resources/lib/handler/jdownloaderHandler.py
+++ b/resources/lib/handler/jdownloaderHandler.py
@@ -75,8 +75,15 @@ class cJDownloaderHandler:
         sAutomaticStart = '0'
         if (bAutomaticDownload == True):
             sAutomaticStart = '1'
-            
-        sUrl = 'http://' + str(sHost) + ':' + str(sPort) + '/action/add/links/grabber' + str(sGrabber) + '/start' + str(sAutomaticStart) + '/' + sFileUrl
+
+        if sPort != '':
+            sUrl = str(sHost) + ':' + str(sPort) + '/action/add/links/grabber' + str(sGrabber) + '/start' + str(sAutomaticStart) + '/' + sFileUrl
+        else:
+            sUrl = str(sHost) + '/action/add/links/grabber' + str(sGrabber) + '/start' + str(sAutomaticStart) + '/' + sFileUrl
+
+        if not sUrl.startswith("http"):
+            sUrl = "http://" + sUrl
+
         return sUrl
 
     def __checkConnection(self):
@@ -84,8 +91,14 @@ class cJDownloaderHandler:
         sHost = self.__getHost()
         sPort = self.__getPort()
 
-        sLinkForJd = 'http://' + str(sHost) + ':' + str(sPort)
-        
+        if sPort != '':
+            sLinkForJd = str(sHost) + ':' + str(sPort)
+        else:
+            sLinkForJd = str(sHost)
+
+        if not sLinkForJd.startswith("http"):
+            sLinkForJd = "http://" + sLinkForJd
+
         try:
             oRequestHandler = cRequestHandler(sLinkForJd)
             oRequestHandler.request()

--- a/resources/lib/handler/pyLoadHandler.py
+++ b/resources/lib/handler/pyLoadHandler.py
@@ -28,10 +28,12 @@ class cPyLoadHandler:
             mydata = urllib.urlencode(mydata)
 
             #check if host has a leading http://
-            if(py_host.find('http://') != 0):
+            if(py_host.find('http') != 0):
                 py_host = 'http://'+py_host
-            logger.info('Attemting to connect to PyLoad at: '+py_host+':'+py_port)
-            req = urllib2.Request(py_host+':'+py_port+'/api/login', mydata)
+            if py_port != ''
+                py_host = py_host+':'+py_port
+            logger.info('Attemting to connect to PyLoad at: '+py_host)
+            req = urllib2.Request(py_host+'/api/login', mydata)
             req.add_header("Content-type", "application/x-www-form-urlencoded")
             page = urllib2.urlopen(req).read()
             page = page[1:]
@@ -40,7 +42,7 @@ class cPyLoadHandler:
             opener.addheaders.append(('Cookie', 'beaker.session.id='+session))
             #pyLoad doesn't like utf-8, so converting Package name to ascii, also stripping any characters that do not belong into a path name (\/:*?"<>|)
             sPackage=str(sPackage).decode("utf-8").encode('ascii','replace').translate(maketrans('\/:*?"<>|', '_________'))
-            py_url=py_host+':'+py_port+'/api/addPackage?name="' + urllib.quote_plus(sPackage) + '"&links=["' + urllib.quote_plus(sUrl) + '"]'
+            py_url=py_host+'/api/addPackage?name="' + urllib.quote_plus(sPackage) + '"&links=["' + urllib.quote_plus(sUrl) + '"]'
             logger.info('PyLoad API call: '+py_url)
             sock = opener.open(py_url)
             logger.info('123')

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -150,17 +150,17 @@
     <setting label="30070" type="sep" />
     <setting default="false" id="jd_enabled" label="30071" type="bool" />
     <setting default="127.0.0.1" enable="!eq(-1,false)" id="jd_host" label="30072" type="text" />
-    <setting default="10025" enable="!eq(-2,false)" id="jd_port" label="30073" type="number" />
+    <setting default="10025" enable="!eq(-2,false)" id="jd_port" label="30073" type="text" />
     <setting default="true" enable="!eq(-3,false)" id="jd_automatic_start" label="30074" type="bool" />
     <setting default="false" enable="!eq(-4,false)" id="jd_grabber" label="30075" type="bool" />
     <setting label="30076" type="sep" />
     <setting default="false" id="jd2_enabled" label="30077" type="bool" />
     <setting default="127.0.0.1" enable="!eq(-1,false)" id="jd2_host" label="30072" type="text" />
-    <setting default="9666" enable="!eq(-2,false)" id="jd2_port" label="30073" type="number" />
+    <setting default="9666" enable="!eq(-2,false)" id="jd2_port" label="30073" type="text" />
     <setting type="sep" />
     <setting default="false" id="pyload_enabled" label="30082" type="bool" />
     <setting default="127.0.0.1" enable="!eq(-1,false)" id="pyload_host" label="30072" type="text" />
-    <setting default="8000" enable="!eq(-2,false)" id="pyload_port" label="30073" type="number" />
+    <setting default="8000" enable="!eq(-2,false)" id="pyload_port" label="30073" type="text" />
     <setting default="user" enable="!eq(-3,false)" id="pyload_user" label="30083" type="text" />
     <setting default="" enable="!eq(-4,false)" id="pyload_passwd" label="30084" option="hidden" type="text" />
   </category> 


### PR DESCRIPTION
This will enable usage of a DNS address and also `https`.

Example:
- host: `https://<your-dns-name>`
- port: <empty>
