### PR TITLE
myjdapi: fix python3 str/byte decode issue

### DIFF
--- a/resources/lib/handler/myjdapi.py
+++ b/resources/lib/handler/myjdapi.py
@@ -320,7 +320,7 @@ class Myjdapi:
     def __encrypt(self, secret_token, data):
         data = PAD(data.encode('utf-8'))
         length = 16 - (len(data) % 16)
-        data += chr(length) * length
+        data += chr(length).encode() * length
         init_vector = secret_token[:len(secret_token) // 2]
         key = secret_token[len(secret_token) // 2:]
         encryptor = pyaes.Encrypter(pyaes.AESModeOfOperationCBC(key, init_vector))


### PR DESCRIPTION
Leider ist mir ein python3 String decode durch die Finger gerutscht.
Nun funktioniert es mit Kodi Leia und Matrix.

Es gibt eine neue python3 myjdapi.py aber diese ist dann nicht mehr Leia kompatibel.
Daher nur dieser "kleine fix".