### PR TITLE
Serienstream: Erweiterte/ genauere Suche als Zusatzoption hinzugefügt 

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -151,6 +151,10 @@ msgctxt "#30052"
 msgid "Use for Global Search"
 msgstr "Für die Globale Suche benutzen"
 
+msgctxt "#30053"
+msgid "Use Advanced Search"
+msgstr "Detaillierte Suche nutzen"
+
 msgctxt "#30060"
 msgid "Use automatically generated views"
 msgstr "Automatisch erzeugte Ansichten verwenden"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -153,6 +153,10 @@ msgctxt "#30052"
 msgid "Use for Global Search"
 msgstr ""
 
+msgctxt "#30053"
+msgid "Use Advanced Search"
+msgstr ""
+
 msgctxt "#30060"
 msgid "Use automatically generated views"
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -451,6 +451,11 @@
 					</dependencies>	
 					<control type="toggle"/>					
 				</setting>
+				 <setting id="serienstream_to-advsearch" type="boolean" label="30053">
+                                        <level>0</level>
+                                        <default>True</default>
+                                        <control type="toggle"/>
+                                </setting>
 				<setting id="serienstream_to-domain" type="string" label="30051">
 					<level>0</level>
 					<default>s.to</default>

--- a/sites/serienstream_to.py
+++ b/sites/serienstream_to.py
@@ -3,6 +3,7 @@
 # Always pay attention to the translations in the menu!
 
 # 2022-12-06 Heptamer - Suchfunktion überarbeitet
+# 2022-12-10 suuhm - Erweiterte Metadata Suchfunktion hinzugefügt
 
 import xbmcgui
 import time
@@ -56,7 +57,10 @@ def load(): # Menu structure of the site plugin
         cGui().addFolder(cGuiElement(cConfig().getLocalizedString(30517), SITE_IDENTIFIER, 'showValue'), params)    # From A-Z
         params.setParam('sCont', 'homeContentGenresList')
         cGui().addFolder(cGuiElement(cConfig().getLocalizedString(30506), SITE_IDENTIFIER, 'showValue'), params)    # Genre
-        cGui().addFolder(cGuiElement(cConfig().getLocalizedString(30520), SITE_IDENTIFIER, 'showSearch'), params)   # Search
+        if cConfig().getSetting('serienstream_to-advsearch'):
+            cGui().addFolder(cGuiElement(cConfig().getLocalizedString(30520), SITE_IDENTIFIER, 'showSearchAdv'), params)   # Search
+        else:
+            cGui().addFolder(cGuiElement(cConfig().getLocalizedString(30520), SITE_IDENTIFIER, 'showSearch'), params)   # Search
         cGui().setEndOfDirectory()
 
 
@@ -348,3 +352,91 @@ def SSsearch(sGui=False, sSearchText=False):
             oGui.addFolder(oGuiElement, params, True, total)
         if not sGui:
             oGui.setView('tvshows')
+
+#
+# Advanced Metadata Search
+#
+def showSearchAdv():
+    sSearchText = cGui().showKeyBoard()
+    if not sSearchText: return
+    _searchAdv(False, sSearchText)
+    cGui().setEndOfDirectory()
+
+
+def _searchAdv(oGui, sSearchText):
+    SSsearchAdv(oGui, sSearchText)
+
+
+def SSsearchAdv(sGui, sSearchText):
+    from json import loads
+    #import xbmc, sys
+    oGui = cGui()
+    params = ParameterHandler()
+    params.getValue('sSearchText')
+
+    oRequest = cRequestHandler(URL_SERIES, caching=True, ignoreErrors=(sGui is not False))
+    oRequest.addHeaderEntry('X-Requested-With', 'XMLHttpRequest')
+    oRequest.addHeaderEntry('Referer', 'https://s.to/serien')
+    oRequest.addHeaderEntry('Origin', 'https://s.to')
+    oRequest.addHeaderEntry('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8')
+    oRequest.addHeaderEntry('Upgrade-Insecure-Requests', '1')
+
+    sHtmlContent = oRequest.request()
+    if not sHtmlContent:
+            return
+
+    sst = sSearchText.lower()
+    #xbmc.log(str(sHtmlContent),2)
+
+    pattern = '<li><a data.+?href="([^"]+)".+?">(.*?)\<\/a><\/l' #link - title
+
+    oParser = cParser()
+    aResult = oParser.parse(sHtmlContent, pattern)
+
+    if not aResult[0]:
+        oGui.showInfo('xStream', 'Es wurde kein Eintrag gefunden')
+        return
+
+    total = len(aResult[1])
+    for link, title in aResult[1]:
+        if not sst in title.lower():
+            continue
+        else:
+            #get images thumb / descr pro call. (optional)
+            sThumbnail, sDescription = getMetaInfo(link, title)
+            oGuiElement = cGuiElement(title, SITE_IDENTIFIER, 'showSeasons')
+            oGuiElement.setThumbnail(sThumbnail)
+            oGuiElement.setDescription(sDescription)
+            oGuiElement.setMediaType('tvshow')
+            #GuiElement.setYear(year)
+            params.setParam('sUrl', URL_MAIN + link)
+            params.setParam('sName', title)
+            oGui.addFolder(oGuiElement, params, True, total)
+        if not sGui:
+            oGui.setView('tvshows')
+
+
+def getMetaInfo(link, title):   # Setzen von Metadata in Suche:
+    #import xbmc, sys
+    oRequest = cRequestHandler(URL_MAIN + link, caching=False)
+    oRequest.addHeaderEntry('X-Requested-With', 'XMLHttpRequest')
+    oRequest.addHeaderEntry('Referer', 'https://s.to/serien')
+    oRequest.addHeaderEntry('Origin', 'https://s.to')
+
+    #GET CONTENT OF HTML
+    sHtmlContent = oRequest.request()
+    if not sHtmlContent:
+        return
+
+    #xbmc.log(str(sHtmlContent),2)
+    pattern = 'seriesCoverBox">.*?<img src="(http.\:.+?)"\ al.+?data-full-description="([^"]+)"' #img , descr
+
+    oParser = cParser()
+    aResult = oParser.parse(sHtmlContent, pattern)
+
+    if not aResult[0]:
+        oGui.showInfo('xStream', 'Es wurde kein Eintrag gefunden')
+        return
+
+    for sImg, sDescr in aResult[1]:
+        return sImg, sDescr

--- a/sites/serienstream_to.py
+++ b/sites/serienstream_to.py
@@ -57,7 +57,7 @@ def load(): # Menu structure of the site plugin
         cGui().addFolder(cGuiElement(cConfig().getLocalizedString(30517), SITE_IDENTIFIER, 'showValue'), params)    # From A-Z
         params.setParam('sCont', 'homeContentGenresList')
         cGui().addFolder(cGuiElement(cConfig().getLocalizedString(30506), SITE_IDENTIFIER, 'showValue'), params)    # Genre
-        if cConfig().getSetting('serienstream_to-advsearch'):
+        if cConfig().getSetting('serienstream_to-advsearch') == 'true':
             cGui().addFolder(cGuiElement(cConfig().getLocalizedString(30520), SITE_IDENTIFIER, 'showSearchAdv'), params)   # Search
         else:
             cGui().addFolder(cGuiElement(cConfig().getLocalizedString(30520), SITE_IDENTIFIER, 'showSearch'), params)   # Search


### PR DESCRIPTION
Da ich aktuell mit der ajax suche fast nur probleme hatte sachen zu finden (zB bei eingabe von bestimmten Suchwörtern keins oder falsches Ergebnis) hab ich hier eine alternative mal zugebaut, welche neben des besseren Findens folegende features hat:

- Thumbnails und Beschreibung direkt in der Anfrage
- Genaueres finden 
- Deaktiviertes Caching, etwas schneller bei Suchanfragen
- Option zu den s.to SiteSettings hinzugefügt, dadurch kann jederzeit zwischen Ajax und neuer Suche gewechselt werden, bei Geschwindigkeitsptoblemen evtl. (sollte aber nicht notwendig sein)